### PR TITLE
Added new parameter legendWithoutBox to avoid the color box next to legend

### DIFF
--- a/projects/showcase/src/app/components/chart/showcase-chart.component.html
+++ b/projects/showcase/src/app/components/chart/showcase-chart.component.html
@@ -56,9 +56,9 @@
                             [lineTension]="0.4"></systelab-chart>
         </div>
         <div class="col-md-6  p-2">
-            <showcase-title [href]="'chart'">Line Chart with Annotation (Lines)</showcase-title>
-            <systelab-chart [labels]="labelLineAnnotations" [data]="dataLineAnnotation" [showLegend]="legendOff" [type]="'line'"
-                            [yMaxValue]="yMaxValue"
+            <showcase-title [href]="'chart'">Line Chart with Annotation (Lines) Legend without color box</showcase-title>
+            <systelab-chart [labels]="labelLineAnnotations" [data]="dataLineAnnotation" [showLegend]="legend" [type]="'line'"
+                            [yMaxValue]="yMaxValue" [legendWithoutBox]="true"
                             [yMinValue]="yMinValue" [annotations]="chartLineAnnotations" [xAutoSkip]="false"></systelab-chart>
         </div>
         <div class="col-md-6  p-2">

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/chart.component.ts
+++ b/projects/systelab-charts/src/lib/chart/chart.component.ts
@@ -208,6 +208,7 @@ export class ChartComponent implements AfterViewInit {
 	@Input() multipleYAxisScales: Array<ChartMultipleYAxisScales>;
 	@Input() customLegend = false;
 	@Input() chartMeterConfiguration: ChartMeterConfiguration;
+	@Input() legendWithoutBox = false;
 
 	private dataset: Array<any> = [];
 
@@ -315,7 +316,11 @@ export class ChartComponent implements AfterViewInit {
 					display:             true,
 					legend:              {
 						display:  this.showLegend,
-						position: this.legendPosition
+						position: this.legendPosition,
+						...this.legendWithoutBox ? {
+							labels: {
+								boxWidth: 0
+						}} : {}
 					},
 					legendCallback:      function(chart) {
 						const text = [];


### PR DESCRIPTION
Added new parameter to avoid the color box next to lengend

![image](https://user-images.githubusercontent.com/722614/139208264-67a620e1-7131-4a17-99f7-733719c38d60.png)

It's useful in some cases when there is only one legend.
 By default is false and the square is showed to avoid breaking changes.

Issue associated: https://github.com/systelab/systelab-charts/issues/98
