### PR TITLE
Adding new option to remove first and last tick

### DIFF
--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "9.1.1",
+  "version": "9.2.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/chart.component.ts
+++ b/projects/systelab-charts/src/lib/chart/chart.component.ts
@@ -209,6 +209,7 @@ export class ChartComponent implements AfterViewInit {
 	@Input() customLegend = false;
 	@Input() chartMeterConfiguration: ChartMeterConfiguration;
 	@Input() legendWithoutBox = false;
+	@Input() hideInitialAndFinalTick = false;
 
 	private dataset: Array<any> = [];
 
@@ -362,7 +363,10 @@ export class ChartComponent implements AfterViewInit {
 								ticks:      {
 									min:     this.yMinValue,
 									max:     this.yMaxValue,
-									display: this.axesVisible
+									display: this.axesVisible,
+									...this.hideInitialAndFinalTick ? {
+										callback: this.removeInitialAndFinalTick
+									} : {}
 								},
 								gridLines:  {
 									display:    this.isBackgroundGrid,
@@ -379,7 +383,10 @@ export class ChartComponent implements AfterViewInit {
 								min:      this.xMinValue,
 								max:      this.xMaxValue,
 								display:  this.axesVisible,
-								autoSkip: this.xAutoSkip
+								autoSkip: this.xAutoSkip,
+								...this.hideInitialAndFinalTick ? {
+									callback: this.removeInitialAndFinalTick
+								} : {}
 							},
 							gridLines:  {
 								display:    this.isBackgroundGrid,
@@ -537,6 +544,10 @@ export class ChartComponent implements AfterViewInit {
 
 			this.chart = new Chart(cx, definition);
 		}
+	}
+
+	private removeInitialAndFinalTick(value, index, values): string {
+		return index === 0 || index === values.length - 1 ? '' : value;
 	}
 
 	private initDatalabelsFontProperties(chartLabelText: ChartLabelFont): object {


### PR DESCRIPTION
Issue related: https://github.com/systelab/systelab-charts/issues/103

Added new option removeInitialAndFinalTick (false by default)
Sometimes when the axes are not set in (0,0) position the first tick overlaps over the second, and the last tick shows the max value although is near of the previous tick.


Example with removeInitialAndFinalTick = false
![image](https://user-images.githubusercontent.com/722614/141803508-71432622-fc72-418a-a352-75ae2ed91b9c.png)

With removeInitialAndFinalTick = true

![image](https://user-images.githubusercontent.com/722614/141803696-4bb3413f-7f4c-4f20-889b-a9cf57e25cc0.png)




