### PR TITLE
Add draw line with free coordinates

### DIFF
--- a/projects/showcase/src/app/components/chart/showcase-chart.component.html
+++ b/projects/showcase/src/app/components/chart/showcase-chart.component.html
@@ -1,9 +1,9 @@
 <div class="container-fluid">
     <div class="row mt-1">
         <div class="col-md-6  p-2">
-            <showcase-title [href]="'chart'">Line Chart</showcase-title>
+            <showcase-title [href]="'chart'">Line Chart with added manual line</showcase-title>
             <systelab-chart #lineChart [labels]="labels" [data]="dataLine" [showLegend]="legend" [type]="'line'" [lineTension]="0.4"
-                            [xLabelAxis]="xLabelAxis" [yLabelAxis]="yLabelAxis" [tooltipSettings]="tooltipSettings"></systelab-chart>
+                            [xLabelAxis]="xLabelAxis" [yLabelAxis]="yLabelAxis" [tooltipSettings]="tooltipSettings" [chartLine]="chartLine"></systelab-chart>
             <button class="btn btn-primary btn-sm" (click)="doChange();">Random Line Chart Values</button>
         </div>
         <div class="col-md-6  p-2">

--- a/projects/showcase/src/app/components/chart/showcase-chart.component.ts
+++ b/projects/showcase/src/app/components/chart/showcase-chart.component.ts
@@ -1,8 +1,9 @@
-import { Component, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
+
 import {
 	Annotation, ChartBoxAnnotation, ChartComponent, ChartItem, ChartLabelAnnotation, ChartLabelColor,
 	ChartLabelFont, ChartLabelPadding, ChartLabelPosition, ChartLabelSettings, ChartLineAnnotation, ChartMultipleYAxisScales,
-	ChartTooltipItem, ChartTooltipSettings, ChartMeterConfiguration
+	ChartTooltipItem, ChartTooltipSettings, ChartMeterConfiguration, ChartLine
 } from 'systelab-charts';
 
 @Component({
@@ -65,6 +66,7 @@ export class ShowcaseChartComponent {
 	public defaultResizeWidth = 1280;
 	public defaultResizeHeight = 900;
 	public resizedImage: string;
+	public chartLine: ChartLine;
 
 	private static randomIntFromInterval(min, max) {
 		return Math.floor(Math.random() * (max - min + 1) + min);
@@ -206,7 +208,10 @@ export class ShowcaseChartComponent {
 			4, undefined, undefined, undefined, undefined, 'dots'));
 		this.dataLineCustomLegend.push(new ChartItem('Line and Area', [12, 41, 1, 21], '', '', true, true,
 			false, 3, undefined, undefined, undefined, undefined, 'bar'));
-	}
+
+			this.chartLine = new ChartLine(0.5, 5, 2.5, 20, null, null);
+
+		}
 
 	public doAction(event: any) {
 		const xValue = this.labels[this.itemSelected._index];

--- a/projects/systelab-charts/README.md
+++ b/projects/systelab-charts/README.md
@@ -99,26 +99,26 @@ Multiple charts example:
 
 ### GridLine
 
-| Name | Type | Default | Description | 
+| Name | Type | Default | Description |
 | ---- |:----:|:------: | --------- |
 | display | boolean | true | Set true if you want to see the grid lines |
-| drawBorder | boolean | true | Set true if you want to see a border around the grid| 
+| drawBorder | boolean | true | Set true if you want to see a border around the grid|
 
 ### ScaleLabel
 
-| Name | Type | Default | Description | 
+| Name | Type | Default | Description |
 | ---- |:----:|:------: | --------- |
 | display | boolean | true | Show the label |
-| labelString | string | | Set a text to be shown in the axis | 
+| labelString | string | | Set a text to be shown in the axis |
 
 ### Ticks
 
-| Name | Type | Default | Description | 
+| Name | Type | Default | Description |
 | ---- |:----:|:------: | --------- |
 | min | number | | Min value for the axis |
-| max | number | | Max value for the axis | 
-| stepSize | number | | Set the steps between axis values | 
-| display | boolean | true | Set to false if you do not want to see the ticks on the axis | 
+| max | number | | Max value for the axis |
+| stepSize | number | | Set the steps between axis values |
+| display | boolean | true | Set to false if you do not want to see the ticks on the axis |
 
 ### Annotations
 
@@ -163,6 +163,19 @@ You can define two types of annotations, line or box type annotations.
 | backgroundColor | string |  | Define the color of the background |
 | fontStyle | string |  | Define the styles of the text |
 | fontColor | string |  | Define the color of the label |
+
+
+#### ChartLine
+Draw a simple line
+
+| Name | Type | Default | Description |
+| ---- |:----:|:-------:| ----------- |
+| xMinValue | any | 0 | Min value of the axis X |
+| yMinValue | any | 0 | Min value of the axis Y |
+| xMaxValue | any | 0 | Max value of the axis X |
+| yMaxValue | any | 0 | Max value of the axis Y |
+| borderColor | string | black | Define the color of the line |
+| borderWidth | string |  | Define the width of the line |
 
 ### Tooltips
 
@@ -314,7 +327,7 @@ this.pieChartLabelSettings.position.display = displayFunction;
 | ---- |:----:|:-------:| ----------- |
 | font | object | null| An object that can be used as a shorthand to specify the family, size, style, weight and lineHeight parameters, see object's definition below. Usually, if this parameter is defined the rest of the parameters, family, size, etc are set as undefined. But if they don't, their values will substituted the ones defined in "font" |
 | family | string | "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"| Font family for the text of all the labels|
-| size | number | 12| Labels' font size|   
+| size | number | 12| Labels' font size|
 | style | string | 'normal'| Labels' font style. The possible values are 'italic', 'oblique' and 'normal'|
 | weight | string or number | 'normal'| Labels' font weight. The possible values are 'bold', 'bolder', 'lighter', 'normal' and a number (e.g. 100, 200, etc|
 | lineHeight | string or number | 1.2| Defines the space between each line in the labels' text (if the need more than one line)|
@@ -375,7 +388,7 @@ Padding = number | {
 | Name | Type | Default | Description |
 | ---- |:----:|:-------:| ----------- |
 | borderColor | string |'#007bff'| The border color applied to the graph |
-| numberFormat | string | | The number format to apply the values | 
+| numberFormat | string | | The number format to apply the values |
 | chartColour | string | | The color for the bars in the history chart |
 | goalColour | string | | The color for the goal values in the history chart |
 | betterValues | string | | Pending description |

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "license": "MIT",
   "keywords": [
     "Angular",


### PR DESCRIPTION
Added chartLine propery to draw a line with free coordinates to have more control than chartLineAnnotations.
[Issue 112](https://github.com/systelab/systelab-charts/issues/112)

Added example in showcase:

![image](https://user-images.githubusercontent.com/722614/152406674-e86f6ba5-8281-4b5a-ac84-720f937af0ea.png)

