### PR TITLE
Adding default display false to ChartDataLabels

### DIFF
--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "14.0.0",
+  "version": "14.0.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/chart.component.ts
+++ b/projects/systelab-charts/src/lib/chart/chart.component.ts
@@ -586,6 +586,12 @@ export class ChartComponent implements AfterViewInit {
 						textShadowColor: this.chartLabelSettings.chartLabelText.textShadowColor
 					}
 				};
+			} else {
+				definition.options.plugins = {
+					datalabels: {
+							display: false
+						}
+					};
 			}
 			this.chart = new Chart(cx, definition);
 		}


### PR DESCRIPTION
Adding a default configuration to hide chartDataLabels by default.

Issue: https://github.com/systelab/systelab-charts/issues/139
