### PR TITLE
#164 The X and Y max/min value inputs do not work when the data is less or greater than the limit

### DIFF
--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "15.1.0",
+  "version": "15.1.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/chart.component.ts
+++ b/projects/systelab-charts/src/lib/chart/chart.component.ts
@@ -589,9 +589,9 @@ export class ChartComponent implements AfterViewInit {
 		const yAxisMultiple = this.multipleYAxisScales ? arrayToObject(yAxisMultipleArray, i => i.id) : null;
 		const yAxis = {
 			stacked:    this.isStacked,
+			min:     this.yMinValue,
+			max:     this.yMaxValue,
 			ticks:      {
-				min:     this.yMinValue,
-				max:     this.yMaxValue,
 				display: this.axesVisible,
 				...this.hideInitialAndFinalTick ? {
 					callback: this.removeInitialAndFinalTick
@@ -619,9 +619,9 @@ export class ChartComponent implements AfterViewInit {
 		} : {};
 		const xAxis = {
 			stacked:    this.isStacked,
+			min:      this.xMinValue,
+			max:      this.xMaxValue,
 			ticks:      {
-				min:      this.xMinValue,
-				max:      this.xMaxValue,
 				display:  this.axesVisible,
 				autoSkip: this.xAutoSkip,
 				...this.hideInitialAndFinalTick ? {


### PR DESCRIPTION
# PR Details

The library ignoring X and Y max/min values has been corrected.

## Related Issue

#164 

## How Has This Been Tested

This fixing has been tested against Chrome and Edge web-browsers.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [ ] I have updated the documentation accordingly (README.md for each UI component)
- [ ] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [ ] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)