### PR TITLE
feature-180

### DIFF
--- a/projects/systelab-charts/README.md
+++ b/projects/systelab-charts/README.md
@@ -155,17 +155,17 @@ You can define two types of annotations, line or box type annotations.
 
 #### chartLineAnnotation
 
-| Name | Type | Default | Description |
-| ---- |:----:|:-------:| ----------- |
-| label | chartLabelAnnotation| | chartLabelAnnotation are the properties of the tooltip label |
-| value | number | | In this case will be 'box' |
-| orientation | string |  | Define the orientation can be 'vertical' or horizontal |
-| drawTime | string |  | Set to draw 'afterDatasetsDraw' or 'beforeDatasetsDraw' |
-| type | string |  | In this case will be 'line' |
-| borderDash | Array<number> |  | If you want a dashed line you will establish the dash properties in a number array |
-| borderColor | string | | Define the color of the box |
-| borderWidth | string |  | Define the width of the border |
-| endValue | number |  | Define a end value of the line, drawing a diagonal line |
+| Name |         Type         | Default | Description                                                                                                                                                 |
+| ---- |:--------------------:|:-------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| label | chartLabelAnnotation | | chartLabelAnnotation are the properties of the tooltip label                                                                                                |
+| value |    number/string     | | If the ticks are strings and we want an annotation relative to one of this label value should be string otherwise number relative to the total ticks number |
+| orientation |        string        |  | Define the orientation can be 'vertical' or horizontal                                                                                                      |
+| drawTime |        string        |  | Set to draw 'afterDatasetsDraw' or 'beforeDatasetsDraw'                                                                                                     |
+| type |        string        |  | In this case will be 'line'                                                                                                                                 |
+| borderDash |    Array<number>     |  | If you want a dashed line you will establish the dash properties in a number array                                                                          |
+| borderColor |        string        | | Define the color of the box                                                                                                                                 |
+| borderWidth |        string        |  | Define the width of the border                                                                                                                              |
+| endValue |        number        |  | Define a end value of the line, drawing a diagonal line                                                                                                     |
 
 #### chartLabelAnnotation
 

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart-legacy/chart-legacy.component.ts
+++ b/projects/systelab-charts/src/lib/chart-legacy/chart-legacy.component.ts
@@ -58,7 +58,7 @@ export class ChartItem {
 
 export class Annotation {
 	constructor(public drawTime: string, public type: string, public borderColor?: string, public borderWidth?: number,
-				public scaleId = 'yAxis') {
+				public scaleId = 'y') {
 	}
 }
 
@@ -654,7 +654,7 @@ export class ChartLegacyComponent implements AfterViewInit {
 				...timeScale,
 				...xAxis,
 			},
-			yAxis: undefined,
+			y: undefined
 		};
 
 		if (this.multipleYAxisScales) {
@@ -662,12 +662,9 @@ export class ChartLegacyComponent implements AfterViewInit {
 				...scales,
 				...yAxisMultiple,
 			};
-			delete scales.yAxis;
+			delete scales.y
 		} else {
-			scales = {
-				...scales,
-				yAxis,
-			};
+			scales.y = yAxis;
 		}
 
 		return scales;
@@ -837,6 +834,8 @@ export class ChartLegacyComponent implements AfterViewInit {
 			lineAnnotation.borderWidth = 2;
 		}
 
+		lineAnnotation.endValue = lineAnnotation.endValue ?? lineAnnotation.value;
+
 		if (lineAnnotation.label) {
 			if (!lineAnnotation.label.backgroundColor) {
 				lineAnnotation.label.backgroundColor = defaultBackgroundColor;
@@ -855,8 +854,8 @@ export class ChartLegacyComponent implements AfterViewInit {
 			drawTime:    lineAnnotation.drawTime,
 			id: 		 'annotation' + (this._annotations.length + 1),
 			type:        lineAnnotation.type,
-			value:		 lineAnnotation.orientation === 'vertical' ? lineAnnotation.value.toString(): lineAnnotation.value,
-			endValue:    lineAnnotation.endValue,
+			value:		 lineAnnotation.value,
+			endValue:	 lineAnnotation.endValue,
 			borderColor: lineAnnotation.borderColor,
 			borderWidth: lineAnnotation.borderWidth,
 			borderDash:  lineAnnotation.borderDash,
@@ -868,7 +867,7 @@ export class ChartLegacyComponent implements AfterViewInit {
 			label = {
 				display:         true,
 					backgroundColor: lineAnnotation.label.backgroundColor,
-					position:        'start',
+					position:        lineAnnotation.label.position,
 					content:         lineAnnotation.label.text,
 					font: {
 					color: lineAnnotation.label.fontColor,

--- a/projects/systelab-charts/src/lib/chart-legacy/services/tooltip-legacy.service.ts
+++ b/projects/systelab-charts/src/lib/chart-legacy/services/tooltip-legacy.service.ts
@@ -91,7 +91,7 @@ export class TooltipLegacyService {
 
         if (item.chartTooltipItem) {
             const chartTooltipItem = item.chartTooltipItem instanceof Array ?
-                item.chartTooltipItem[tooltipItem.index] : item.chartTooltipItem;
+                item.chartTooltipItem[tooltipItem.dataIndex] : item.chartTooltipItem;
             if (chartTooltipItem.afterLabel) {
                 afterLabel = chartTooltipItem.afterLabel;
             }

--- a/projects/systelab-charts/src/lib/chart/services/annotation.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/annotation.service.ts
@@ -115,8 +115,8 @@ export class AnnotationService {
             borderColor: annotation.border?.color ?? undefined,
             borderWidth: annotation.border?.width ?? 2,
             borderDash: annotation.border?.dash ? [5, 15] : undefined,
-            value: isVertical ? annotation.value.toString() : Number(annotation.value),
-            endValue: isVertical ? endValue.toString() : Number(endValue),
+            value: annotation.value,
+            endValue: endValue,
             label: computedLabel,
         };
     }


### PR DESCRIPTION
Fixed the annotations to don't convert the value to string in vertical orientation.

Now the value can be numeric or string. If it's string it should be equal to some of the ticks, if it's numeric the annotation will be placed relative to the length of the array ticks or to the axe if there is no ticks.
For example if the ticks are ['1','2','3','4'] a value of '2' will draw the annotation on '2' tick, a value of 1.5 will draw beetween '2' and '3' because will placed relative to 0 - 3  (number of elements of the array).