### PR TITLE
Feature 197 - Add support for point annotations

### DIFF
--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "17.1.5",
+  "version": "17.2.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/interfaces/annotation.ts
+++ b/projects/systelab-charts/src/lib/chart/interfaces/annotation.ts
@@ -1,4 +1,4 @@
-export type AnnotationTypes = LineAnnotation | BoxAnnotation;
+export type AnnotationTypes = LineAnnotation | BoxAnnotation | PointAnnotation;
 
 interface Annotation {
     type: AnnotationType;
@@ -7,6 +7,21 @@ interface Annotation {
     backgroundColor?: string;
 }
 
+export enum AnnotationType {
+    line = 'line',
+    box = 'box',
+    point = 'point',
+}
+
+export enum AnnotationDrawTime {
+    afterDraw = 'afterDraw',
+    afterDatasetsDraw = 'afterDatasetsDraw',
+    beforeDraw = 'beforeDraw',
+    beforeDatasetsDraw = 'beforeDatasetsDraw',
+}
+
+
+// Line annotations
 export interface LineAnnotation extends Annotation {
     label?: AnnotationLabel;
     value: number | string;
@@ -19,10 +34,39 @@ export interface LineAnnotation extends Annotation {
     };
 }
 
+export enum LineAnnotationOrientation {
+    vertical = 'vertical',
+    horizontal = 'horizontal',
+}
+
 export interface LineAnnotationDefaultConfiguration extends Omit<LineAnnotation, 'value' | 'type' | 'label'> {
     label?: Omit<AnnotationLabel, 'display' | 'text'>;
 }
 
+export interface AnnotationLabel {
+    display: boolean;
+    text: string; // content
+    position?: AnnotationLabelLabelPosition;
+    backgroundColor?: string;
+    font?: {
+        style: string;
+        color: string;
+    };
+    border?: {
+        width?: number;
+        color?: string;
+        radius?: number;
+    };
+}
+
+export enum AnnotationLabelLabelPosition {
+    start = 'start',
+    center = 'center',
+    end = 'end',
+}
+
+
+// Box annotations
 export interface BoxAnnotation extends Annotation {
     limits: {
         x: {
@@ -43,41 +87,20 @@ export interface BoxAnnotation extends Annotation {
     };
 }
 
-export interface AnnotationLabel {
-    display: boolean;
-    text: string; // content
-    position?: AnnotationLabelLabelPosition;
-    backgroundColor?: string;
-    font?: {
-        style: string;
-        color: string;
-    };
+
+// Point annotations
+export interface PointAnnotation extends Annotation {
+    x: number;
+    y: number;
+    xAxisID?: string;
+    yAxisID?: string;
+    radius?: number;
     border?: {
         width?: number;
         color?: string;
-        radius?: number;
     };
 }
 
-export enum AnnotationType {
-    line = 'line',
-    box = 'box',
-}
 
-export enum AnnotationLabelLabelPosition {
-    start = 'start',
-    center = 'center',
-    end = 'end',
-}
 
-export enum AnnotationDrawTime {
-    afterDraw = 'afterDraw',
-    afterDatasetsDraw = 'afterDatasetsDraw',
-    beforeDraw = 'beforeDraw',
-    beforeDatasetsDraw = 'beforeDatasetsDraw',
-}
 
-export enum LineAnnotationOrientation {
-    vertical = 'vertical',
-    horizontal = 'horizontal',
-}

--- a/projects/systelab-charts/src/lib/chart/services/annotation.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/annotation.service.ts
@@ -6,7 +6,8 @@ import {
     BoxAnnotation,
     LineAnnotation,
     LineAnnotationDefaultConfiguration,
-    LineAnnotationOrientation
+    LineAnnotationOrientation,
+    PointAnnotation
 } from '../interfaces';
 
 const defaultAnnotationColor = 'rgb(229, 60, 41)';
@@ -44,10 +45,13 @@ export class AnnotationService {
         if (!annotations || annotations.length === 0) {
             return undefined;
         }
+
         const computedAnnotations = [];
         for( const annotation of annotations) {
             if (this.isBoxAnnotation(annotation)) {
                 computedAnnotations.push(this.mapBoxAnnotation(annotation));
+            } else if(this.isPointAnnotation(annotation)) {
+                computedAnnotations.push(this.mapPointAnnotation(annotation));
             } else if (this.isLineAnnotation(annotation)) {
                 computedAnnotations.push(this.mapLineAnnotation({
                     ...defaultLineAnnotationConfiguration,
@@ -73,6 +77,7 @@ export class AnnotationService {
                 // error
             }
         }
+
         return computedAnnotations;
     }
 
@@ -87,6 +92,21 @@ export class AnnotationService {
             xMin: annotation.limits.x.min,
             yMax: annotation.limits.y.max,
             yMin: annotation.limits.y.min,
+            drawTime: annotation.drawTime ?? AnnotationDrawTime.afterDatasetsDraw,
+        };
+    }
+
+    private mapPointAnnotation(annotation: PointAnnotation) {
+        return {
+            type: 'point',
+            xValue: annotation.x,
+            yValue: annotation.y,
+            xScaleID: annotation.xAxisID,
+            yScaleID: annotation.yAxisID,
+            radius: annotation.radius ?? 2,
+            backgroundColor: annotation.backgroundColor ?? 'transparent',
+            borderWidth: annotation.border?.width ?? 2,
+            borderColor: annotation.border?.color ?? undefined,
             drawTime: annotation.drawTime ?? AnnotationDrawTime.afterDatasetsDraw,
         };
     }
@@ -125,6 +145,10 @@ export class AnnotationService {
 
     private isBoxAnnotation(object: any): object is BoxAnnotation {
         return 'limits' in object;
+    }
+
+    private isPointAnnotation(object: any): object is PointAnnotation {
+        return 'type' in object && object.type === 'point';
     }
 
     private isLineAnnotation(object: any): object is LineAnnotation {

--- a/projects/systelab-charts/src/lib/chart/services/annotation.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/annotation.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import {
     AnnotationDrawTime,
     AnnotationLabelLabelPosition,
+    AnnotationType,
     AnnotationTypes,
     BoxAnnotation,
     LineAnnotation,
@@ -47,7 +48,7 @@ export class AnnotationService {
         }
 
         const computedAnnotations = [];
-        for( const annotation of annotations) {
+        for (const annotation of annotations) {
             if (this.isBoxAnnotation(annotation)) {
                 computedAnnotations.push(this.mapBoxAnnotation(annotation));
             } else if(this.isPointAnnotation(annotation)) {
@@ -83,7 +84,7 @@ export class AnnotationService {
 
     private mapBoxAnnotation(annotation: BoxAnnotation) {
         return {
-            type: 'box',
+            type: AnnotationType.box,
             backgroundColor: annotation.backgroundColor ?? 'transparent',
             borderColor: annotation.border?.color ?? undefined,
             borderRadius: annotation.border?.radius ?? undefined,
@@ -98,7 +99,7 @@ export class AnnotationService {
 
     private mapPointAnnotation(annotation: PointAnnotation) {
         return {
-            type: 'point',
+            type: AnnotationType.point,
             xValue: annotation.x,
             yValue: annotation.y,
             xScaleID: annotation.xAxisID,
@@ -130,7 +131,7 @@ export class AnnotationService {
             };
         }
         return {
-            type: 'line',
+            type: AnnotationType.line,
             scaleID: isVertical ? 'x' : annotation.axisID,
             backgroundColor: annotation.backgroundColor ?? undefined,
             borderColor: annotation.border?.color ?? undefined,
@@ -143,15 +144,15 @@ export class AnnotationService {
         };
     }
 
-    private isBoxAnnotation(object: any): object is BoxAnnotation {
-        return 'limits' in object;
+    private isBoxAnnotation(annotation: AnnotationTypes): annotation is BoxAnnotation {
+        return 'limits' in annotation;
     }
 
-    private isPointAnnotation(object: any): object is PointAnnotation {
-        return 'type' in object && object.type === 'point';
+    private isPointAnnotation(annotation: AnnotationTypes): annotation is PointAnnotation {
+        return 'type' in annotation && annotation.type === AnnotationType.point;
     }
 
-    private isLineAnnotation(object: any): object is LineAnnotation {
-        return 'type' in object && object.type === 'line';
+    private isLineAnnotation(annotation: AnnotationTypes): annotation is LineAnnotation {
+        return 'type' in annotation && annotation.type === AnnotationType.line;
     }
 }


### PR DESCRIPTION
# PR Details

Added support for point annotations. This type of annotations are used to mark points on the chart area. They can be useful for highlighting values that are of interest.

This feature is provided by the chartjs-plugin-annotation (https://www.chartjs.org/chartjs-plugin-annotation/latest/guide/types/point.html), thus this PR exposes through the systelab-charts library interface this functionality.

## Related Issue

This pull request resolves issue #197.

## Motivation and Context

This is required to display points on calibration charts.

## How Has This Been Tested

Tested through local use of the updated package in a real project.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
