### PR TITLE
Parameterize language in some charts

### DIFF
--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/interfaces/axes.ts
+++ b/projects/systelab-charts/src/lib/chart/interfaces/axes.ts
@@ -1,3 +1,5 @@
+import { Locale } from "date-fns";
+
 export interface Axes {
     isHorizontal?: boolean;
     mainAxis?: 'x' | 'y'; // default x
@@ -30,6 +32,11 @@ export interface AxisContent {
     grid?: {
         display: boolean;
     };
+    adapters?:{
+        date: {
+            locale: Locale;
+        }
+    }
 }
 
 export interface Ticks {


### PR DESCRIPTION
Add the language in the ChartConfiguration interface to show the line chart with timeline of the user language