### PR TITLE
Feature 214: Add support for scatter charts

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -57,7 +57,9 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "dist/showcase",
+            "outputPath": {
+              "base": "dist/showcase"
+            },
             "index": "projects/showcase/src/index.html",
             "polyfills": [
               "projects/showcase/src/polyfills.ts"

--- a/angular.json
+++ b/angular.json
@@ -57,9 +57,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": {
-              "base": "dist/showcase"
-            },
+            "outputPath": "dist/showcase",
             "index": "projects/showcase/src/index.html",
             "polyfills": [
               "projects/showcase/src/polyfills.ts"

--- a/projects/showcase/src/app/components/showcase-chart/chart-types/index.ts
+++ b/projects/showcase/src/app/components/showcase-chart/chart-types/index.ts
@@ -9,3 +9,5 @@ export * from './line-multiple-axis-chart';
 export * from './pie-chart';
 export * from './polar-area-chart';
 export * from './radar-chart';
+export * from './scatter-chart';
+export * from './scatter-chart-with-show-line';

--- a/projects/showcase/src/app/components/showcase-chart/chart-types/scatter-chart-with-show-line.ts
+++ b/projects/showcase/src/app/components/showcase-chart/chart-types/scatter-chart-with-show-line.ts
@@ -4,7 +4,7 @@ export const scatterChartShowingLineConfiguration: ChartConfiguration = {
     type: ChartType.scatter,
     datasets: [
         {
-            label: 'Only Points',
+            label: 'Line',
             data: [{
                 x: -10,
                 y: 0
@@ -19,10 +19,8 @@ export const scatterChartShowingLineConfiguration: ChartConfiguration = {
                 y: 5.5
               }
             ],
-            border: {
-                width: 3,
-            },
             showLine: true,
+            pointRadius: 0
         },
     ],
 };

--- a/projects/showcase/src/app/components/showcase-chart/chart-types/scatter-chart-with-show-line.ts
+++ b/projects/showcase/src/app/components/showcase-chart/chart-types/scatter-chart-with-show-line.ts
@@ -1,0 +1,28 @@
+import { ChartConfiguration, ChartType } from 'systelab-charts';
+
+export const scatterChartShowingLineConfiguration: ChartConfiguration = {
+    type: ChartType.scatter,
+    datasets: [
+        {
+            label: 'Only Points',
+            data: [{
+                x: -10,
+                y: 0
+              }, {
+                x: 0,
+                y: 10
+              }, {
+                x: 10,
+                y: 5
+              }, {
+                x: 0.5,
+                y: 5.5
+              }
+            ],
+            border: {
+                width: 3,
+            },
+            showLine: true,
+        },
+    ],
+};

--- a/projects/showcase/src/app/components/showcase-chart/chart-types/scatter-chart.ts
+++ b/projects/showcase/src/app/components/showcase-chart/chart-types/scatter-chart.ts
@@ -1,0 +1,28 @@
+import { ChartConfiguration, ChartType } from 'systelab-charts';
+
+export const scatterChartConfiguration: ChartConfiguration = {
+    type: ChartType.scatter,
+    datasets: [
+        {
+            label: 'Only Points',
+            data: [{
+                x: -10,
+                y: 0
+              }, {
+                x: 0,
+                y: 10
+              }, {
+                x: 10,
+                y: 5
+              }, {
+                x: 0.5,
+                y: 5.5
+              }
+            ],
+            border: {
+                width: 3,
+            },
+            showLine: false,
+        },
+    ],
+};

--- a/projects/showcase/src/app/components/showcase-chart/showcase-chart.component.html
+++ b/projects/showcase/src/app/components/showcase-chart/showcase-chart.component.html
@@ -10,7 +10,6 @@
             <systelab-chart [config]="lineMultipleAxisChartConfiguration"></systelab-chart>
         </div>
 
-
         <div class="col-md-6  p-2">
             <app-showcase-title [href]="'chart'">Line Chart with timeline</app-showcase-title>
             <systelab-chart [config]="lineChartWithTimelineConfiguration"></systelab-chart>
@@ -75,6 +74,16 @@
         <div class="col-md-6  p-2">
             <app-showcase-title [href]="'chart'">Line Chart with line legend ,click event disabled and tooltip title prefix</app-showcase-title>
             <systelab-chart [config]="lineChartWithLineLegendConfiguration"></systelab-chart>
+        </div>
+
+        <div class="col-md-6  p-2">
+            <app-showcase-title [href]="'chart'">Scatter Chart</app-showcase-title>
+            <systelab-chart [config]="scatterChartConfiguration"></systelab-chart>
+        </div>
+
+        <div class="col-md-6  p-2">
+            <app-showcase-title [href]="'chart'">Scatter Chart showing line</app-showcase-title>
+            <systelab-chart [config]="scatterChartShowingLineConfiguration"></systelab-chart>
         </div>
     </div>
 </div>

--- a/projects/showcase/src/app/components/showcase-chart/showcase-chart.component.ts
+++ b/projects/showcase/src/app/components/showcase-chart/showcase-chart.component.ts
@@ -11,7 +11,9 @@ import {
   lineMultipleAxisChartConfiguration,
   pieChartConfiguration,
   polarAreaChartConfiguration,
-  radarChartConfiguration
+  radarChartConfiguration,
+  scatterChartConfiguration,
+  scatterChartShowingLineConfiguration, 
 } from './chart-types';
 import { lineChartWithAnnotationLinesConfiguration } from './chart-types/line-chart-with-annotation-lines';
 import { bubbleChartWithAnnotationBoxConfiguration } from './chart-types/bubble-chart-with-annotation-box';
@@ -40,4 +42,6 @@ export class ShowcaseChartComponent {
   public bubbleChartWithAnnotationBoxConfiguration: ChartConfiguration = bubbleChartWithAnnotationBoxConfiguration;
   public bubbleChartWithAnnotationBoxLineConfiguration: ChartConfiguration = bubbleChartWithAnnotationBoxLineConfiguration;
   public lineChartWithLineLegendConfiguration: ChartConfiguration = lineChartWithLineLegendConfiguration;
+  public scatterChartConfiguration: ChartConfiguration = scatterChartConfiguration;
+  public scatterChartShowingLineConfiguration: ChartConfiguration = scatterChartShowingLineConfiguration;
 }

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "18.0.0",
+  "version": "18.1.0",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/interfaces/dataset.ts
+++ b/projects/systelab-charts/src/lib/chart/interfaces/dataset.ts
@@ -1,6 +1,6 @@
 import { ChartType } from './chart-configuration';
 
-export type Dataset = LineDataset | BarDataset | BubbleDataset | TimeDataset;
+export type Dataset = LineDataset | BarDataset | BubbleDataset | TimeDataset | ScatterDataset;
 
 export interface BaseDataset {
     label?: string;
@@ -73,4 +73,16 @@ export interface TimePoint {
 export interface TimeDatasetBorderStyle {
     width?: number;
     color?: string | number[];
+}
+
+
+// Scatter dataset
+export interface ScatterDataset extends BaseDataset {
+    data: ScatterPoint[];
+    showLine: boolean;
+}
+
+export interface ScatterPoint {
+    x: number;
+    y: number;
 }

--- a/projects/systelab-charts/src/lib/chart/interfaces/dataset.ts
+++ b/projects/systelab-charts/src/lib/chart/interfaces/dataset.ts
@@ -20,11 +20,13 @@ export interface BaseDataset {
 // Line dataset
 export interface LineDataset extends BaseDataset {
     data: number[];
-    border?: {
-        color?: string | number[];
-        width?: number;
-        dash?: number[];
-    };
+    border?: LineDatasetBorderStyle | LineDatasetBorderStyle[];
+}
+
+export interface LineDatasetBorderStyle {
+    color?: string | number[];
+    width?: number;
+    dash?: number[];
 }
 
 
@@ -80,6 +82,7 @@ export interface TimeDatasetBorderStyle {
 export interface ScatterDataset extends BaseDataset {
     data: ScatterPoint[];
     showLine: boolean;
+    border?: LineDatasetBorderStyle | LineDatasetBorderStyle[];
 }
 
 export interface ScatterPoint {

--- a/projects/systelab-charts/src/lib/chart/interfaces/dataset.ts
+++ b/projects/systelab-charts/src/lib/chart/interfaces/dataset.ts
@@ -82,10 +82,16 @@ export interface TimeDatasetBorderStyle {
 export interface ScatterDataset extends BaseDataset {
     data: ScatterPoint[];
     showLine: boolean;
-    border?: LineDatasetBorderStyle | LineDatasetBorderStyle[];
+    border?: ScatterDatasetBorderStyle | ScatterDatasetBorderStyle[];
 }
 
 export interface ScatterPoint {
     x: number;
     y: number;
+}
+
+export interface ScatterDatasetBorderStyle {
+    color?: string | number[];
+    width?: number;
+    dash?: number[];
 }

--- a/projects/systelab-charts/src/lib/chart/services/dataset.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/dataset.service.ts
@@ -90,10 +90,7 @@ export class DatasetService {
             datalabels: inputDataset.datalabels,
         };
 
-        if (chartType === ChartType.scatter || inputDataset.type === 'scatter') {
-            const scatterInputDataset: ScatterDataset = inputDataset as ScatterDataset;
-            outputDataset['showLine'] = scatterInputDataset.showLine;
-        }
+        this.fillForScatterChart(chartType, inputDataset, outputDataset);
 
         return outputDataset;
     }
@@ -126,5 +123,14 @@ export class DatasetService {
 
     private toRGBA(colour: number[], alpha: number = 1): string {
         return `rgba(${colour.concat(alpha).join(',')})`;
+    }
+
+    private fillForScatterChart(chartType: ChartType, inputDataset: Dataset, outputDataset: object) {
+        if (chartType !== ChartType.scatter && inputDataset.type !== 'scatter') {
+            return;
+        }
+
+        const scatterInputDataset: ScatterDataset = inputDataset as ScatterDataset;
+        outputDataset['showLine'] = scatterInputDataset.showLine;
     }
 }

--- a/projects/systelab-charts/src/lib/chart/services/dataset.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/dataset.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ChartConfiguration, ChartType, Dataset, Legend } from '../interfaces';
+import { ChartConfiguration, ChartType, Dataset, Legend, ScatterDataset } from '../interfaces';
 import * as ChartJS from 'chart.js';
 
 @Injectable({
@@ -89,6 +89,12 @@ export class DatasetService {
             ...(pointStyleEnabled && pointStyle && { pointStyle }),
             datalabels: inputDataset.datalabels,
         };
+
+        if (inputDataset.type === 'scatter') {
+            const scatterInputDataset = outputDataset as any as ScatterDataset;
+            outputDataset['showLine'] = scatterInputDataset.showLine;
+        }
+
         return outputDataset;
     }
 

--- a/projects/systelab-charts/src/lib/chart/services/dataset.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/dataset.service.ts
@@ -90,8 +90,8 @@ export class DatasetService {
             datalabels: inputDataset.datalabels,
         };
 
-        if (inputDataset.type === 'scatter') {
-            const scatterInputDataset = outputDataset as any as ScatterDataset;
+        if (chartType === ChartType.scatter || inputDataset.type === 'scatter') {
+            const scatterInputDataset: ScatterDataset = inputDataset as ScatterDataset;
             outputDataset['showLine'] = scatterInputDataset.showLine;
         }
 


### PR DESCRIPTION
# PR Details

Added support for scatter charts. This type of charts are used to draw points defined by X and Y on the chart area.

This feature is provided directly by the underlying ChartJS library: https://www.chartjs.org/docs/latest/charts/scatter.html

## Related Issue

This pull request resolves issue #214.

## Motivation and Context

This is required to display calibration charts, which include a curve that represents the mapping with 2 numerical units.

## How Has This Been Tested

Tested through new examples added into the showcase.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
