### PR TITLE
Bugfix-217: Allow disabling tooltip titles (Angular 17)

### DIFF
--- a/projects/showcase/src/app/components/showcase-chart/chart-types/line-chart-with-line-legend.ts
+++ b/projects/showcase/src/app/components/showcase-chart/chart-types/line-chart-with-line-legend.ts
@@ -51,6 +51,7 @@ export const lineChartWithLineLegendConfiguration: ChartConfiguration = {
     tooltip: {
         enabled: true,
         title: {
+            enabled: true,
             prefix: 'Time: ',
         }
     },

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "17.4.0",
+  "version": "17.4.1",
   "license": "MIT",
   "keywords": [
     "Angular",

--- a/projects/systelab-charts/src/lib/chart/interfaces/tooltip.ts
+++ b/projects/systelab-charts/src/lib/chart/interfaces/tooltip.ts
@@ -3,6 +3,7 @@ export interface Tooltip {
     position?: string;
     backgroundColor?: string;
     title?: {
+        enabled?: boolean; // default false
         text?: string; // If undefined we use the X axis value
         prefix?: string;
         fontSize?: string;

--- a/projects/systelab-charts/src/lib/chart/services/tooltip.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/tooltip.service.ts
@@ -15,7 +15,7 @@ export class TooltipService {
             usePointStyle: pointStyleEnabled,
             callbacks: {
                 title: (tooltipItems) => {
-                    let enabled = tooltip?.title?.enabled ?? false;
+                    const enabled = tooltip?.title?.enabled ?? false;
                     if (!enabled) {
                         return null;
                     }

--- a/projects/systelab-charts/src/lib/chart/services/tooltip.service.ts
+++ b/projects/systelab-charts/src/lib/chart/services/tooltip.service.ts
@@ -9,11 +9,17 @@ export class TooltipService {
     public mapTooltip(chartConfiguration: ChartConfiguration) {
         const { tooltip } = chartConfiguration;
         const { enabled: pointStyleEnabled} = chartConfiguration.legend?.labels ?? { enabled: false};
+
         return {
             enabled: tooltip?.enabled ?? true,
             usePointStyle: pointStyleEnabled,
             callbacks: {
                 title: (tooltipItems) => {
+                    let enabled = tooltip?.title?.enabled ?? false;
+                    if (!enabled) {
+                        return null;
+                    }
+
                     let title = tooltip?.title?.text ?? undefined;
                     const prefix = tooltip?.title?.prefix ?? undefined;
                     if (!title) {


### PR DESCRIPTION
# PR Details

Added new `enabled` property to `tooltip.title` configuration object to allow disabling titles of tooltips. Updated also default behavior to have tooltip titles disabled.

## Related Issue

This pull request resolves issue #217.

## Motivation and Context

This is required to polish the tooltips needed for certain calibration charts, that don't require a title on the tooltip and there's no way to disable it.

## How Has This Been Tested

Tested through an updated example of the showcase.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation 
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
