### PR TITLE
259 - Documentation modified to warn developers to add chartJS-plugin…

### DIFF
--- a/projects/systelab-charts/README.md
+++ b/projects/systelab-charts/README.md
@@ -2,6 +2,8 @@
 
 Component to show a Chart
 
+__IMPORTANT__: It is required to install chartjs-plugin-zoom to integrate the library in your project with no errors.
+
 ## Using the component
 
 ```html
@@ -478,6 +480,8 @@ Levels = {
 | doResizeChart | string, string | Perform a chart resize based on the height and width parameters (in pixels).|
 
 ## Zoom & Pan plugin
+
+__IMPORTANT__: It is required to install this plugin to integrate the library in your project with no errors.
 
 Please, refer to [Chart.js Zoom & Pan plugin documentation](https://www.chartjs.org/chartjs-plugin-zoom/latest/) for more details about how to use zoom and pan features in the systelab-chart component.
 

--- a/projects/systelab-charts/package.json
+++ b/projects/systelab-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systelab-charts",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "license": "MIT",
   "keywords": [
     "Angular",


### PR DESCRIPTION
# PR Details

ChartJS-plugin-zoom is required to be installed in the project

## Description

Error: ChartJS-plugin-error is required to be installed in the project to avoid integration errors

## Related Issue
#259

## Motivation and Context

Solve integration errros

## How has this been tested

It has been executed tests

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation